### PR TITLE
fix: getSecret response type

### DIFF
--- a/src/lib/integrations/integrations.ts
+++ b/src/lib/integrations/integrations.ts
@@ -4,6 +4,7 @@ import {
     CreateDuoIntegrationPayload,
     DuoIntegration,
     DuoIntegrationClientSecret,
+    DuoIntegrationSecretKeyV1,
     DuoIntegrationsListParams,
     UpdateDuoIntegrationPayload,
 } from './integrations.types'
@@ -46,7 +47,7 @@ export class Integrations {
      * @param integrationKey
      * @returns
      */
-    async getSecret(integrationKey: string): Promise<DuoIntegrationClientSecret> {
+    async getSecret(integrationKey: string): Promise<DuoIntegrationSecretKeyV1> {
         const { data } = await this.httpAgent.get(`/admin/v1/integrations/${integrationKey}/skey`)
         return this.unwrapResponse(data)
     }

--- a/src/lib/integrations/integrations.types.ts
+++ b/src/lib/integrations/integrations.types.ts
@@ -192,3 +192,7 @@ export interface UpdateDuoIntegrationPayload extends DuoIntegrationUpsertPayload
 export interface DuoIntegrationClientSecret {
     client_secret: string
 }
+
+export interface DuoIntegrationSecretKeyV1 {
+    secret_key: string
+}

--- a/src/lib/utils/create-http-agent.spec.ts
+++ b/src/lib/utils/create-http-agent.spec.ts
@@ -90,6 +90,29 @@ describe('HttpAgent', () => {
         expect(request.headers.Date).toEqual(expect.any(String))
     })
 
+    it('uses the v5 signer for legacy integrations secret requests', () => {
+        const interceptor = getRequestInterceptor()
+        const request = interceptor({
+            method: 'get',
+            url: '/admin/v1/integrations/DI123/skey',
+            headers: {},
+        })
+
+        expect(signV5Spy).toHaveBeenCalledWith(
+            conf.integrationKey,
+            conf.secretKey,
+            'GET',
+            conf.apiHost,
+            '/admin/v1/integrations/DI123/skey',
+            {},
+            expect.any(String),
+            '',
+        )
+        expect(signSpy).not.toHaveBeenCalled()
+        expect(request.headers.Authorization).toBe('Basic v5-signature')
+        expect(request.headers.Date).toEqual(expect.any(String))
+    })
+
     it('uses the v5 signer with the serialized JSON body for integrations writes', () => {
         const interceptor = getRequestInterceptor()
         const payload = { name: 'Admin API', type: 'adminapi' }

--- a/src/lib/utils/create-http-agent.ts
+++ b/src/lib/utils/create-http-agent.ts
@@ -3,7 +3,11 @@ import { DuoConfig } from '../duo.types'
 import { sign, signV5 } from './hmac'
 
 function isV5SignaturePath(path: string) {
-    return path.startsWith('/admin/v3/integrations') || path.startsWith('/admin/v2/integrations')
+    return (
+        path.startsWith('/admin/v3/integrations') ||
+        path.startsWith('/admin/v2/integrations') ||
+        path.startsWith('/admin/v1/integrations')
+    )
 }
 
 function stripUndefinedValues(value: Record<string, unknown>) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request-signing behavior for all `/admin/v1/integrations` endpoints, which could break calls if any of those endpoints still expect the older signature scheme. Type-only changes to `getSecret` are low risk but may require downstream compile fixes.
> 
> **Overview**
> Fixes the legacy `Integrations.getSecret` API to return the correct response shape (`secret_key`) via a new `DuoIntegrationSecretKeyV1` type.
> 
> Updates HTTP request signing so any `/admin/v1/integrations/...` call (including the legacy `/skey` endpoint) uses the v5 signer, and adds a unit test covering this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74b3feb514c2016abff5a49c80cfa59f8a3b911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->